### PR TITLE
Fix README links broken by master->main rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ A way for you to understand why I am here and for us to measure success.  This i
 
 It comes in 2 flavors:
 
-[manager](https://github.com/brianbegy/brianbegy/blob/master/manager.md) and [team lead](https://github.com/brianbegy/brianbegy/blob/master/lead.md) depending on what I'm doing in this job.
+[manager](manager.md) and [team lead](lead.md) depending on what I'm doing in this job.


### PR DESCRIPTION
The `master` -> `main` rename broke the two absolute GitHub URLs in the README (they pointed at `/blob/master/...`).

Switched them to **relative links** (`manager.md`, `lead.md`) so they render correctly on the profile page and can't break on any future rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)