### PR TITLE
Add CI to enforce Prettier formatting

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,18 @@
+name: format
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check


### PR DESCRIPTION
The pre-commit hook is local and can be bypassed with `--no-verify`. This adds CI so formatting is actually enforced.

- GitHub Actions workflow runs `npm run format:check` (`prettier --check .`) on every pull request and on pushes to `main`.
- Once this lands and the check has reported once, I'll wire it in as a **required status check** in branch protection so nothing merges unformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)