### PR TITLE
Polish Metrics: remove the double-list seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,8 @@ That means I:
 
 ## Metrics
 
-I like to count things.
+I like to count things. Some of what I count is the health of the product and the system we run:
 
-- Story points help us understand our capacity and our velocity.
 - Bug counts tell us if we have a quality problem.
 - Production support tickets tell us where we need to improve the system.
 - Performance metrics ensure our products work the way we need them to.
@@ -192,7 +191,7 @@ I like to count things.
 
 I don't want to be ruled by metrics, but they let us stay on top of the chaos. If our metrics ever seem to be driving the wrong behavior, we need to stop and talk about it. See [Feedback](#feedback).
 
-A caveat that matters more every day: when a model can open ten PRs before lunch, output volume gets cheap. Counting code produced increasingly measures the tool, not the person. So I weight the output metrics below lightly, and I care most about **judgment** — did we ship the right thing, did we catch the subtly-wrong thing, and what escaped to production.
+The rest are about measuring _us_ — how we plan and what we deliver — and this is where I tread carefully. A caveat that matters more every day: when a model can open ten PRs before lunch, output volume gets cheap. Counting code produced increasingly measures the tool, not the person. So I weight the output metrics below lightly, and I care most about **judgment** — did we ship the right thing, did we catch the subtly-wrong thing, and what escaped to production.
 
 ### Output metrics
 


### PR DESCRIPTION
The Metrics section had two lists that named different metrics: an intro bullet list (story points, bug counts, support tickets, performance, monitoring) and detailed subsections (story points, PR throughput, escaped defects, cycle time, delivery days). Only story points appeared in both — and its flat-positive intro line ("help us understand our capacity and velocity") contradicted the nuanced take in the Output metrics subsection.

This scopes the intro list to what it's really about — **product/system health** — drops story points from it (the Output section owns it), and adds a bridge sentence into the self-measurement subsections. One metric, one place, no contradiction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)