### PR TITLE
Collapse the guide behind a details toggle on the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 A way for you to understand why I am here and for us to measure success. This is heavily inspired by [Rands](http://randsinrepose.com/archives/how-to-rands/) and others.
 
+<details>
+<summary>📖 <strong>Read the full working-with-me guide</strong></summary>
+
 ## Contents
 
 - [My role](#my-role)
@@ -229,3 +232,5 @@ I am a strong believer that every developer should engage with the codebase and 
   - AI note takers are welcome — they capture more than we can while staying present in the conversation. But the transcript is a draft, not the record. A human reads it, corrects what the model misheard or misattributed, and owns the version we keep. Same rule as everywhere else: the machine does the work, a person owns the judgment.
 - Story grooming is important to get everybody on the same page.
 - Retrospectives are important to help us improve.
+
+</details>


### PR DESCRIPTION
The README fills the whole profile home page. This keeps the title, résumé link, and one-line intro visible, then wraps everything from Contents onward in a single native GitHub \`<details>\` toggle ("📖 Read the full working-with-me guide"). Collapsed by default, one click to expand.

Uses the blank-line-after-\`<summary>\` pattern so the markdown (headings, lists, TOC) inside renders normally once expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)